### PR TITLE
Clone handling replications in dependency order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ changes between minor versions.
 
 - The `--prune-format` options was not being used for bookmarks. This has now
   been fixed.
+- Clone handling now replicates in dependency order, and checks that
+  excluded parent datasets exist before starting replication
 
 ## [0.1.1] - 2025-01-11
 


### PR DESCRIPTION
For clone handling we replicate child datasets in dependency order. This allows us to handle complicated hierarchies.

Closes #3 